### PR TITLE
fix: Correct skipped files un-skipping

### DIFF
--- a/internal/files/file.go
+++ b/internal/files/file.go
@@ -46,6 +46,7 @@ func (f *File) Update(ctx context.Context, version int, content string) {
 	}
 	f.Version = version
 	f.Content = content
+	f.Skip = false
 
 	f.SimpleAST, f.Err = ParseSimpleObjectFile(content)
 	if f.Err != nil {

--- a/internal/files/filesystem_test.go
+++ b/internal/files/filesystem_test.go
@@ -425,6 +425,22 @@ func TestFS_UpdateFile(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:            "previously skipped file is no longer skipped",
+			uri:             "file://file1",
+			content:         "apiVersion: n9/",
+			expectedContent: "apiVersion: n9/",
+			version:         2,
+			skipped:         false,
+			setup: func(fs *FS) {
+				fs.files["file://file1"] = &File{
+					URI:     "file://file1",
+					Version: 1,
+					Content: "apiVersion: n",
+					Skip:    true,
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Release Notes

Files which were marked as skipped and then un-skipped (e.g. didn't have `apiVersion: n9/` but after an update it has) are now correctly handled, i.e they are being processed by the LSP.
