### PR TITLE
fix: Correct line ranges

### DIFF
--- a/internal/diagnostics/handler_test.go
+++ b/internal/diagnostics/handler_test.go
@@ -644,7 +644,7 @@ func TestHandler_Handle(t *testing.T) {
 						Severity: messages.DiagnosticSeverityError,
 						Source:   ptr(goYamlSource),
 						Range: messages.Range{
-							Start: messages.Position{Line: 1, Character: 1},
+							Start: messages.Position{Line: 1, Character: 0},
 							End:   messages.Position{Line: 1, Character: 1},
 						},
 					},
@@ -666,8 +666,17 @@ func TestHandler_Handle(t *testing.T) {
 						Severity: messages.DiagnosticSeverityError,
 						Source:   ptr(goYamlSource),
 						Range: messages.Range{
-							Start: messages.Position{Line: 6, Character: 3},
-							End:   messages.Position{Line: 6, Character: 3},
+							Start: messages.Position{Line: 6, Character: 2},
+							End:   messages.Position{Line: 6, Character: 4},
+						},
+					},
+					{
+						Message:  `unknown field "project"`,
+						Severity: messages.DiagnosticSeverityError,
+						Source:   ptr(goYamlSource),
+						Range: messages.Range{
+							Start: messages.Position{Line: 15, Character: 2},
+							End:   messages.Position{Line: 15, Character: 9},
 						},
 					},
 				},
@@ -688,8 +697,8 @@ func TestHandler_Handle(t *testing.T) {
 						Severity: messages.DiagnosticSeverityError,
 						Source:   ptr(goYamlSource),
 						Range: messages.Range{
-							Start: messages.Position{Line: 7, Character: 3},
-							End:   messages.Position{Line: 7, Character: 3},
+							Start: messages.Position{Line: 7, Character: 2},
+							End:   messages.Position{Line: 7, Character: 13},
 						},
 						RelatedInformation: []messages.DiagnosticRelatedInformation{
 							{

--- a/internal/diagnostics/provider.go
+++ b/internal/diagnostics/provider.go
@@ -860,13 +860,16 @@ var duplicateYAMLKeyRegexp = regexp.MustCompile(`already defined at \[(\d+):(\d+
 
 func yamlErrorToDiagnostic(yamlError yaml.Error, fileURI string) messages.Diagnostic {
 	token := yamlError.GetToken()
+	start := token.Position.Column - 1
+	end := start + len(token.Value)
 	diag := messages.Diagnostic{
-		Range: newPointRange(
+		Range: newLineRange(
 			// Shift the line number to the actual line in the file as the SDK
 			// operates on the single node's context.
 			// Subtract one to convert StartLine from 1-based to 0-based indexing.
 			token.Position.Line,
-			token.Position.Column,
+			start,
+			end,
 		),
 		Severity: messages.DiagnosticSeverityError,
 		Source:   ptr(goYamlSource),

--- a/internal/diagnostics/testdata/unknown-field.yaml
+++ b/internal/diagnostics/testdata/unknown-field.yaml
@@ -8,3 +8,11 @@ spec:
   description: test annotation
   startTime: 2006-01-02T17:10:05Z
   endTime: 2006-01-02T17:10:05Z
+---
+apiVersion: n9/v1alpha
+kind: Project
+metadata:
+  name: default
+  project: default
+spec:
+  description: test project

--- a/tests/go/server_test.go
+++ b/tests/go/server_test.go
@@ -472,7 +472,7 @@ func TestLSP(t *testing.T) {
 								Severity: messages.DiagnosticSeverityError,
 								Source:   ptr("go-yaml"),
 								Range: messages.Range{
-									Start: messages.Position{Line: 1, Character: 1},
+									Start: messages.Position{Line: 1, Character: 0},
 									End:   messages.Position{Line: 1, Character: 1},
 								},
 							},


### PR DESCRIPTION
## Release Notes

Line ranges for YAML errors, like duplicated key or unknown field were not constructed properly. Now they highlight the full key instead of a single letter.
