### PR TITLE
fix: Correct list of documents parsing

### DIFF
--- a/internal/diagnostics/handler_test.go
+++ b/internal/diagnostics/handler_test.go
@@ -716,6 +716,18 @@ func TestHandler_Handle(t *testing.T) {
 				},
 			},
 		},
+		"data exports (no issues)": {
+			item: messages.TextDocumentItem{
+				URI:     getTestFileURI("data-exports.yaml").URI,
+				Version: 1,
+				Text:    "foo", // Text is not actually relevant.
+			},
+			expected: &messages.PublishDiagnosticsParams{
+				URI:         getTestFileURI("data-exports.yaml").URI,
+				Version:     1,
+				Diagnostics: []messages.Diagnostic{},
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/diagnostics/testdata/data-exports.yaml
+++ b/internal/diagnostics/testdata/data-exports.yaml
@@ -1,0 +1,25 @@
+# gcs
+- apiVersion: n9/v1alpha
+  kind: DataExport
+  metadata:
+    name: gcs-export
+    displayName: Data export to Google Cloud Storage bucket
+    project: default
+  spec:
+    exportType: GCS
+    spec:
+      bucketName: prod-data-export-bucket
+  status: null
+# s3
+- apiVersion: n9/v1alpha
+  kind: DataExport
+  metadata:
+    name: s3-export
+    displayName: Data export to AWS S3 bucket
+    project: default
+  spec:
+    exportType: S3
+    spec:
+      bucketName: data-export-bucket
+      roleArn: arn:aws:iam::123456578901:role/nobl9-access
+  status: null

--- a/internal/files/file_test.go
+++ b/internal/files/file_test.go
@@ -406,6 +406,43 @@ apiVersion: n9/v1alpha
 				},
 			},
 		},
+		{
+			name: "list of objects with comments",
+			content: `# gcs
+- apiVersion: n9/v1alpha
+  kind: DataExport
+# s3
+- apiVersion: n9/v1alpha
+  kind: DataExport`,
+			expectedAST: SimpleObjectFile{
+				{
+					Version:       manifest.VersionV1alpha,
+					Kind:          manifest.KindDataExport,
+					isListElement: true,
+					Doc: &yamlastsimple.Document{
+						Offset: 0,
+						Lines: []*yamlastsimple.Line{
+							{Path: ""},
+							{Path: "$[0].apiVersion"},
+							{Path: "$[0].kind"},
+							{Path: ""},
+						},
+					},
+				},
+				{
+					Version:       manifest.VersionV1alpha,
+					Kind:          manifest.KindDataExport,
+					isListElement: true,
+					Doc: &yamlastsimple.Document{
+						Offset: 4,
+						Lines: []*yamlastsimple.Line{
+							{Path: "$[1].apiVersion"},
+							{Path: "$[1].kind"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/files/simple_object.go
+++ b/internal/files/simple_object.go
@@ -49,7 +49,7 @@ func ParseSimpleObjectFile(content string) (SimpleObjectFile, error) {
 		switch {
 		case len(doc.Lines) == 0:
 			continue
-		case strings.HasPrefix(doc.Lines[0].Path, "$["):
+		case docIsList(doc):
 			docs, err := splitListDocument(doc)
 			if err != nil {
 				return nil, err
@@ -66,6 +66,16 @@ func ParseSimpleObjectFile(content string) (SimpleObjectFile, error) {
 		}
 	}
 	return file, nil
+}
+
+func docIsList(doc *yamlastsimple.Document) bool {
+	for _, line := range doc.Lines {
+		if line.IsType(yamlastsimple.LineTypeList) &&
+			strings.HasPrefix(line.Path, "$[") {
+			return true
+		}
+	}
+	return false
 }
 
 func parseSimpleObjectNode(doc *yamlastsimple.Document) *SimpleObjectNode {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -80,10 +80,6 @@ func (l *Level) UnmarshalText(data []byte) error {
 	return l.Level.UnmarshalText(data)
 }
 
-func DefaultLevel() Level {
-	return Level{Level: slog.LevelInfo}
-}
-
 type Config struct {
 	LogFile  string `json:"logFile"`
 	LogLevel Level  `json:"logLevel"`

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -31,7 +31,11 @@ func LogPanic(ctx context.Context, recovered any) {
 	if recovered == nil {
 		return
 	}
-	slog.ErrorContext(ctx, "panic recovered", slog.Any("panic", recovered))
+	stackTrace := string(debug.Stack())
+	slog.ErrorContext(ctx, "panic recovered",
+		slog.Any("panic", recovered),
+		slog.String("stack", stackTrace))
+
 	notifyClient(ctx, conn, messages.ShowMessageMethod, messages.ShowMessageParams{
 		Type: messages.MessageTypeError,
 		Message: "Nobl9 LSP has encountered an internal error.\n" +
@@ -39,7 +43,7 @@ func LogPanic(ctx context.Context, recovered any) {
 	})
 	notifyClient(ctx, conn, messages.LogMessageMethod, messages.LogMessageParams{
 		Type:    messages.MessageTypeError,
-		Message: fmt.Sprintf("%v\nStack trace:\n%s", recovered, string(debug.Stack())),
+		Message: fmt.Sprintf("%v\nStack trace:\n%s", recovered, stackTrace),
 	})
 }
 

--- a/internal/yamlastsimple/parse_test.go
+++ b/internal/yamlastsimple/parse_test.go
@@ -402,6 +402,29 @@ name: my-service
 				},
 			},
 		},
+		"array elements with comments": {
+			in: `# gcs
+- apiVersion: n9/v1alpha
+  kind: DataExport
+# s3
+- apiVersion: n9/v1alpha
+  kind: DataExport`,
+			out: File{
+				Docs: []*Document{
+					{
+						Offset: 0,
+						Lines: []*Line{
+							{Path: "", indent: 0, Type: LineTypeComment},
+							{Path: "$[0].apiVersion", GeneralizedPath: "$.apiVersion", indent: 2, Type: LineTypeList | LineTypeMapping},
+							{Path: "$[0].kind", GeneralizedPath: "$.kind", indent: 2, Type: LineTypeMapping},
+							{Path: "", indent: 0, Type: LineTypeComment},
+							{Path: "$[1].apiVersion", GeneralizedPath: "$.apiVersion", indent: 2, Type: LineTypeList | LineTypeMapping},
+							{Path: "$[1].kind", GeneralizedPath: "$.kind", indent: 2, Type: LineTypeMapping},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
## Release Notes

When a list of documents was preceded by a comment or an empty line, it would result in a server error. This is now fixed.
