### PR TITLE
fix: Correct re-completion for properties

### DIFF
--- a/docs/neovim-config/add-to-lsp.lua
+++ b/docs/neovim-config/add-to-lsp.lua
@@ -2,11 +2,16 @@ local configs = require("lspconfig.configs")
 
 configs.nobl9_language_server = {
   default_config = {
-    cmd = { "nobl9-language-server" },
+    cmd = {
+      "nobl9-language-server",
+      "-logFilePath=~/.local/state/nobl9-language-server/n9.log",
+      "-logLevel=ERROR",
+    },
     filetypes = { "yaml" },
     root_dir = function(fname)
       return vim.fs.dirname(vim.fs.find(".git", { path = fname, upward = true })[1])
     end,
+    single_file_support = true,
     settings = {},
   },
 }

--- a/docs/neovim-config/init.lua
+++ b/docs/neovim-config/init.lua
@@ -80,6 +80,7 @@ configs.nobl9_language_server = {
     root_dir = function(fname)
       return vim.fs.dirname(vim.fs.find(".git", { path = fname, upward = true })[1])
     end,
+    single_file_support = true,
     settings = {},
   },
 }

--- a/internal/completion/handler_test.go
+++ b/internal/completion/handler_test.go
@@ -62,7 +62,7 @@ func TestHandler_Handle(t *testing.T) {
 					},
 				},
 			},
-			expected: getRootPathCompletionItems(0),
+			expected: removeColonFromItems(getRootPathCompletionItems(0)),
 		},
 		"agent - complete metadata": {
 			params: messages.CompletionParams{
@@ -74,7 +74,7 @@ func TestHandler_Handle(t *testing.T) {
 					},
 				},
 			},
-			expected: metadataPathCompletionItems,
+			expected: removeColonFromItems(metadataPathCompletionItems),
 		},
 		"agent - do not complete metadata if cursor is on value": {
 			params: messages.CompletionParams{
@@ -138,7 +138,7 @@ func TestHandler_Handle(t *testing.T) {
 			expected:       getRootPathCompletionItems(0),
 			ignoreSnippets: true,
 		},
-		"complete apiVersion": {
+		"complete apiVersion - value": {
 			params: messages.CompletionParams{
 				TextDocumentPositionParams: messages.TextDocumentPositionParams{
 					TextDocument: getTestFileURI("complete-apiversion.yaml"),
@@ -150,7 +150,7 @@ func TestHandler_Handle(t *testing.T) {
 			},
 			expected: apiVersionCompletionItems,
 		},
-		"complete apiVersion (array)": {
+		"complete apiVersion - array value": {
 			params: messages.CompletionParams{
 				TextDocumentPositionParams: messages.TextDocumentPositionParams{
 					TextDocument: getTestFileURI("complete-apiversion-array.yaml"),
@@ -162,7 +162,19 @@ func TestHandler_Handle(t *testing.T) {
 			},
 			expected: apiVersionCompletionItems,
 		},
-		"complete kind": {
+		"complete apiVersion - property name": {
+			params: messages.CompletionParams{
+				TextDocumentPositionParams: messages.TextDocumentPositionParams{
+					TextDocument: getTestFileURI("complete-apiversion.yaml"),
+					Position: messages.Position{
+						Line:      1,
+						Character: 2,
+					},
+				},
+			},
+			expected: removeColonFromItems(getRootPathCompletionItems(0)),
+		},
+		"complete kind - value": {
 			params: messages.CompletionParams{
 				TextDocumentPositionParams: messages.TextDocumentPositionParams{
 					TextDocument: getTestFileURI("complete-kind.yaml"),
@@ -622,6 +634,15 @@ func getRootPathCompletionItems(indent int) []messages.CompletionItem {
 			InsertTextFormat: messages.PlainTextTextFormat,
 		},
 	}
+}
+
+func removeColonFromItems(items []messages.CompletionItem) []messages.CompletionItem {
+	copiedItems := make([]messages.CompletionItem, len(items))
+	copy(copiedItems, items)
+	for i := range copiedItems {
+		copiedItems[i].InsertText = copiedItems[i].Label
+	}
+	return copiedItems
 }
 
 var (

--- a/internal/completion/keys_completion.go
+++ b/internal/completion/keys_completion.go
@@ -31,7 +31,7 @@ func (p KeysCompletionProvider) getType() completionProviderType {
 
 func (p KeysCompletionProvider) Complete(
 	_ context.Context,
-	_ messages.CompletionParams,
+	params messages.CompletionParams,
 	_ files.SimpleObjectFile,
 	node *files.SimpleObjectNode,
 	line *yamlastsimple.Line,
@@ -72,6 +72,9 @@ func (p KeysCompletionProvider) Complete(
 		var insertText string
 		isRootSpecOrMetadata := path == "$" && (proposedPath == "spec" || proposedPath == "metadata")
 		switch {
+		case line.GetColonIndex() != -1:
+			// If the line has a colon, we need to insert the text after it.
+			insertText = proposedPath
 		case (prop == nil || len(prop.ChildrenPaths) == 0) && !isRootSpecOrMetadata:
 			// Proposed path is a simple value node.
 			insertText = proposedPath + ": "
@@ -83,6 +86,7 @@ func (p KeysCompletionProvider) Complete(
 			// tabstop character or use workspace/configuration or expose LS config option.
 			insertText = proposedPath + ":\n" + strings.Repeat(" ", line.GetIndent()+2)
 		}
+
 		items = append(items, messages.CompletionItem{
 			Label:            proposedPath,
 			Kind:             messages.PropertyCompletion,

--- a/internal/messages/common.go
+++ b/internal/messages/common.go
@@ -19,6 +19,38 @@ type Location struct {
 	Range Range  `json:"range"`
 }
 
+// NewPointRange returns [Range] with both start and end set to the same line and character.
+func NewPointRange(l, c int) Range {
+	return NewRange(l, c, l, c)
+}
+
+// NewLineRange returns [Range] with both start and end set to the same line.
+func NewLineRange(l, sc, ec int) Range {
+	return NewRange(l, sc, l, ec)
+}
+
+// NewRange returns a [Range] with the given start and end lines and characters.
+// Line numbers are 0-based in the LSP specification, but we operate on 1-based indexing,
+// so we need to subtract one.
+func NewRange(sl, sc, el, ec int) Range {
+	if sl != 0 {
+		sl--
+	}
+	if el != 0 {
+		el--
+	}
+	return Range{
+		Start: Position{
+			Line:      sl,
+			Character: sc,
+		},
+		End: Position{
+			Line:      el,
+			Character: ec,
+		},
+	}
+}
+
 type Range struct {
 	// Zero-based inclusive start position.
 	Start Position `json:"start"`

--- a/internal/yamlastsimple/parse.go
+++ b/internal/yamlastsimple/parse.go
@@ -74,6 +74,12 @@ func (l *Line) HasMapValue() bool {
 	return l.IsType(LineTypeMapping) && l.valueColonIdx != -1 && l.valueColonIdx+2 < len(l.value)
 }
 
+// GetColonIndex returns the index of the colon in the line.
+// If colon is not present, it returns -1.
+func (l *Line) GetColonIndex() int {
+	return l.valueColonIdx
+}
+
 // GetKeyPos returns the start and end position of the key on the given line.
 // End position is exclusive, while start is inclusive.
 func (l *Line) GetKeyPos() (start, end int) {

--- a/internal/yamlastsimple/parse.go
+++ b/internal/yamlastsimple/parse.go
@@ -190,7 +190,7 @@ func parseDocumentLines(lines []string) []*Line {
 		case line[0] == '-':
 			parsedLine.indent += 2
 			parsedLine.Type = LineTypeList
-			if parsedLine.valueColonIdx = strings.Index(line, ":"); parsedLine.valueColonIdx != -1 {
+			if parsedLine.valueColonIdx = getColonIndex(line); parsedLine.valueColonIdx != -1 {
 				parsedLine.Path = strings.TrimSpace(line[1:parsedLine.valueColonIdx])
 				parsedLine.addType(LineTypeMapping)
 			}
@@ -205,7 +205,7 @@ func parseDocumentLines(lines []string) []*Line {
 				parsedLine.Type = LineTypeUndefined
 				break
 			}
-			if parsedLine.valueColonIdx = strings.Index(line, ":"); parsedLine.valueColonIdx != -1 {
+			if parsedLine.valueColonIdx = getColonIndex(line); parsedLine.valueColonIdx != -1 {
 				parsedLine.Path = strings.TrimSpace(line[:parsedLine.valueColonIdx])
 				parsedLine.Type = LineTypeMapping
 			}
@@ -324,6 +324,25 @@ func getIndentLevel(s string) int {
 		ctr++
 	}
 	return ctr
+}
+
+func getColonIndex(s string) int {
+	keyStarted := false
+	for i, r := range s {
+		if i == 0 && r == '-' {
+			continue
+		}
+		isSpace := unicode.IsSpace(r)
+		switch {
+		case keyStarted && isSpace:
+			return -1
+		case !keyStarted && !isSpace:
+			keyStarted = true
+		case r == ':':
+			return i
+		}
+	}
+	return -1
 }
 
 // generalizePath generalizes the root path of the YAML document by:

--- a/internal/yamlastsimple/parse_test.go
+++ b/internal/yamlastsimple/parse_test.go
@@ -546,8 +546,10 @@ func TestLine_HasMapValue(t *testing.T) {
 		{"- metadata:\n  - name:", 1, false},
 	}
 	for _, tc := range tests {
-		file := ParseFile(tc.in)
-		assert.Equal(t, tc.expected, file.Docs[0].Lines[tc.line].HasMapValue())
+		t.Run(tc.in, func(t *testing.T) {
+			file := ParseFile(tc.in)
+			assert.Equal(t, tc.expected, file.Docs[0].Lines[tc.line].HasMapValue())
+		})
 	}
 }
 

--- a/internal/yamlastsimple/parse_test.go
+++ b/internal/yamlastsimple/parse_test.go
@@ -425,6 +425,30 @@ name: my-service
 				},
 			},
 		},
+		"simple list element": {
+			in: `- metadata`,
+			out: File{
+				Docs: []*Document{
+					{
+						Lines: []*Line{
+							{Path: "$[0]", GeneralizedPath: "$", indent: 2, Type: LineTypeList},
+						},
+					},
+				},
+			},
+		},
+		"array doc with colon in string": {
+			in: `- metadata "foo: bar"`,
+			out: File{
+				Docs: []*Document{
+					{
+						Lines: []*Line{
+							{Path: "$[0]", GeneralizedPath: "$", indent: 2, Type: LineTypeList},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/yamlastsimple/parse_test.go
+++ b/internal/yamlastsimple/parse_test.go
@@ -449,6 +449,18 @@ name: my-service
 				},
 			},
 		},
+		"array doc with quoted colon in key": {
+			in: `- "metadata: bar": foo`,
+			out: File{
+				Docs: []*Document{
+					{
+						Lines: []*Line{
+							{Path: `$[0]."metadata: bar"`, GeneralizedPath: `$."metadata: bar"`, indent: 2, Type: LineTypeList | LineTypeMapping},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/yamlastsimple/parse_test.go
+++ b/internal/yamlastsimple/parse_test.go
@@ -672,3 +672,50 @@ func Test_generalizePath(t *testing.T) {
 		})
 	}
 }
+
+func Test_getColonIndex(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		// Simple cases
+		{name: "simple key", input: "key: value", expected: 3},
+		{name: "key with space", input: "key : value", expected: -1},
+		{name: "no colon", input: "key value", expected: -1},
+		{name: "empty string", input: "", expected: -1},
+		{name: "colon at end", input: "key:", expected: 3},
+
+		// List items
+		{name: "list item", input: "- key: value", expected: 5},
+		{name: "list item no colon", input: "- key value", expected: -1},
+
+		// Quoted keys
+		{name: "double quoted key", input: `"key": value`, expected: 5},
+		{name: "single quoted key", input: `'key': value`, expected: 5},
+
+		// Quoted keys with colons inside
+		{name: "double quoted key with colon", input: `"key:with:colon": value`, expected: 16},
+		{name: "single quoted key with colon", input: `'key:with:colon': value`, expected: 16},
+		{name: "mixed quotes in double quotes", input: `"key:'with:colon'": value`, expected: 18},
+		{name: "mixed quotes in single quotes", input: `'key:"with:colon"': value`, expected: 18},
+
+		// Nested quoted strings
+		{name: "nested double quotes", input: `"outer "inner" outer": value`, expected: 21},
+		{name: "nested single quotes", input: `'outer 'inner' outer': value`, expected: 21},
+
+		// Edge cases
+		{name: "unclosed double quotes", input: `"key:with:colon: value`, expected: -1},
+		{name: "unclosed single quotes", input: `'key:with:colon: value`, expected: -1},
+		{name: "escaped quotes not special", input: `key\"with\"colon: value`, expected: 16},
+		{name: "comment after key", input: "key # comment: not value", expected: -1},
+		{name: "space after key", input: "key value: not value", expected: -1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getColonIndex(tc.input)
+			assert.Equal(t, tc.expected, result, "Input: %q", tc.input)
+		})
+	}
+}


### PR DESCRIPTION
## Release Notes

When rewriting properties the completion inserted additional `:` colon, now it only inserts the property name if the colon was already there.
In addition quoted keys with colons and quoted values with colons are now handled properly.