### PR TITLE
chore: support fork PR autolabeling and Go 1.26.4

### DIFF
--- a/.github/workflows/pr-autolabeler.yml
+++ b/.github/workflows/pr-autolabeler.yml
@@ -1,0 +1,19 @@
+name: PR Autolabeler
+
+on:
+  # pull_request_target is required to label PRs from forks.
+  # This workflow must stay metadata-only: do not checkout or run PR code here.
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  autolabeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v6
+        with:
+          token: ${{ github.token }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-  # pull_request event is required only for autolabeler
-  # 'edited' event is required to account for initial invalid PR names
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
-
 permissions:
   contents: read
 
@@ -17,9 +12,6 @@ jobs:
     permissions:
       # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.RELEASE_LABELER_TOKEN }}
@@ -33,5 +25,4 @@ jobs:
       - id: drafter
         uses: release-drafter/release-drafter@v6
       - name: Add release notes to the draft
-        if: github.event_name == 'push'
         run: .github/scripts/release-notes.sh ${{ steps.drafter.outputs.tag_name }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,8 @@ issues:
 
 linters:
   exclusions:
+    paths:
+      - node_modules/
     rules:
     - linters:
         - revive
@@ -97,6 +99,9 @@ linters:
     - whitespace
 
 formatters:
+  exclusions:
+    paths:
+      - node_modules/
   enable:
     - gofmt
     - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,17 @@
+version: "2"
+
 run:
   timeout: 5m
   modules-download-mode: readonly
-  skip-dirs-use-default: true
 
 issues:
+  exclude-dirs-use-default: true
   # Enable all checks (which was by default disabled e.g. comments).
   exclude-use-default: false
-  exclude-rules:
+
+linters:
+  exclusions:
+    rules:
     - linters:
         - revive
       text: exported (function|method|type) .*? should have comment or be unexported
@@ -22,46 +27,40 @@ issues:
     - linters:
         - revive
       text: "error-strings: error strings should not be capitalized or end with punctuation or a newline"
-  # Value 0 means show all.
-  max-issues-per-linter: 0
-  max-same-issues: 0
-
-linters-settings:
-  goimports:
-    # Put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes.
-    local-prefixes: github.com/nobl9/nobl9-language-server
-  govet:
+  settings:
+    govet:
     # False positives and reporting on error shadowing (which is intended).
     # Quoting Rob Pike:
     #   The shadow code is marked experimental.
     #   It has too many false positives to be enabled by default, so this is not entirely unexpected,
     #   but don't expect a fix soon. The right way to detect shadowing without flow analysis is elusive.
     # Few years later (comment from 2015) and the Shadow Analyzer is still experimental...
-    check-shadowing: false
-  lll:
-    line-length: 120
-  gocritic:
-    enabled-tags:
-      - opinionated
-    disabled-checks:
-      - singleCaseSwitch
-      - unnamedResult
-      - ifElseChain
-  exhaustive:
+      check-shadowing: false
+    lll:
+      line-length: 120
+    gocritic:
+      enabled-tags:
+        - opinionated
+      disabled-checks:
+        - singleCaseSwitch
+        - unnamedResult
+        - ifElseChain
+    exhaustive:
     # In switch statement treat label default: as being exhaustive.
-    default-signifies-exhaustive: true
-  misspell:
-    locale: US
-  gocognit:
-    min-complexity: 30
-  revive:
-    rules:
-      - name: unused-parameter
-        disabled: true
+      default-signifies-exhaustive: true
+    misspell:
+      locale: US
+    gocognit:
+      min-complexity: 30
+    revive:
+      rules:
+        - name: unused-parameter
+          disabled: true
 
-linters:
-  disable-all: true
+  # Value 0 means show all.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  default: none
   enable:
     # All linters from list https://golangci-lint.run/usage/linters/ are specified here and explicit enable/disable.
     - asciicheck
@@ -74,11 +73,8 @@ linters:
     - gocognit
     - gocritic
     - gocyclo
-    - gofmt
     - goheader
-    - goimports
     - goprintffuncname
-    - gosimple
     - govet
     - importas
     - ineffassign
@@ -94,9 +90,18 @@ linters:
     - sqlclosecheck
     - staticcheck
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - wastedassign
     - whitespace
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      # Put imports beginning with prefix after 3rd-party packages;
+      # it's a comma-separated list of prefixes.
+      local-prefixes: github.com/nobl9/nobl9-language-server

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LDFLAGS := -s -w \
 # renovate datasource=github-releases depName=securego/gosec
 GOSEC_VERSION := v2.24.7
 # renovate datasource=github-releases depName=golangci/golangci-lint
-GOLANGCI_LINT_VERSION := v1.64.8
+GOLANGCI_LINT_VERSION := v2.12.2
 # renovate datasource=go depName=golang.org/x/vuln/cmd/govulncheck
 GOVULNCHECK_VERSION := v1.1.4
 # renovate datasource=go depName=golang.org/x/tools/cmd/goimports
@@ -176,8 +176,7 @@ install/yarn:
 ## Install golangci-lint (https://golangci-lint.run).
 install/golangci-lint:
 	$(call _print_step,Installing golangci-lint)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh |\
- 		sh -s -- -b $(BIN_DIR) $(GOLANGCI_LINT_VERSION)
+	$(call _install_go_binary,github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 
 ## Install gosec (https://github.com/securego/gosec).
 install/gosec:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nobl9/nobl9-language-server
 
-go 1.24
+go 1.26.4
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1

--- a/internal/codeactions/handler.go
+++ b/internal/codeactions/handler.go
@@ -20,9 +20,9 @@ type objectsRepo interface {
 	Delete(ctx context.Context, objects []manifest.Object) error
 }
 
-func NewHandler(files *files.FS, repo objectsRepo, notifier clientNotifier) *Handler {
+func NewHandler(fileStore *files.FS, repo objectsRepo, notifier clientNotifier) *Handler {
 	return &Handler{
-		files:       files,
+		files:       fileStore,
 		objectsRepo: repo,
 		notifier:    notifier,
 	}

--- a/internal/diagnostics/provider.go
+++ b/internal/diagnostics/provider.go
@@ -161,7 +161,7 @@ func (d Provider) checkUserGroupReferencedObjects(
 	object *files.ObjectNode,
 	group v1alphaUserGroup.UserGroup,
 ) []messages.Diagnostic {
-	var diagnostics []messages.Diagnostic
+	diagnostics := make([]messages.Diagnostic, 0, len(group.Spec.Members))
 	for i, member := range group.Spec.Members {
 		diagnostics = append(diagnostics, d.checkUserExistence(
 			ctx,

--- a/internal/hover/handler.go
+++ b/internal/hover/handler.go
@@ -18,9 +18,9 @@ type providerInterface interface {
 	) *messages.HoverResponse
 }
 
-func NewHandler(files *files.FS, provider providerInterface) *Handler {
+func NewHandler(fileStore *files.FS, provider providerInterface) *Handler {
 	return &Handler{
-		files:    files,
+		files:    fileStore,
 		provider: provider,
 	}
 }

--- a/internal/hover/templates.go
+++ b/internal/hover/templates.go
@@ -67,7 +67,7 @@ func markdownEscape(s string) string {
 const markdownSpecialCharacters = "\\`*_{}[]<>()#+-.!|"
 
 var markdownReplacer = func() *strings.Replacer {
-	var replacements []string
+	replacements := make([]string, 0, 2*len(markdownSpecialCharacters))
 	for _, c := range markdownSpecialCharacters {
 		replacements = append(replacements, string(c), `\`+string(c))
 	}

--- a/tests/go/server_test.go
+++ b/tests/go/server_test.go
@@ -398,7 +398,7 @@ func TestLSP(t *testing.T) {
 			Response: TestCaseResponse{
 				ID: 11,
 				Result: func() []messages.CompletionItem {
-					var items []messages.CompletionItem
+					items := make([]messages.CompletionItem, 0, len(manifest.KindNames()))
 					for _, kind := range manifest.KindNames() {
 						items = append(items, messages.CompletionItem{
 							Label: kind,

--- a/tests/lua/specs/lsp_spec.lua
+++ b/tests/lua/specs/lsp_spec.lua
@@ -134,6 +134,10 @@ Version represents the specific version of the manifest.
 
     local diagnostics = vim.diagnostic.get(bufnr)
     assert(diagnostics and #diagnostics > 0, "Expected diagnostics, but got none")
+    for _, diagnostic in ipairs(diagnostics) do
+      diagnostic.namespace = nil
+      diagnostic._extmark_id = nil
+    end
     local expected = {
       {
         bufnr = bufnr,
@@ -142,7 +146,6 @@ Version represents the specific version of the manifest.
         end_lnum = 2,
         lnum = 2,
         message = "metadata.project: property is required but was empty",
-        namespace = 3,
         severity = 1,
         source = "nobl9-language-server",
         user_data = {


### PR DESCRIPTION
## Motivation

External contributor PRs cannot access repository secrets even after a maintainer approves workflow execution. The previous Release Drafter autolabeler job required a secret token on `pull_request`, so fork PRs failed before labels could be applied.

## Summary

- Moves PR autolabeling to a separate metadata-only `pull_request_target` workflow.
- Uses `github.token` with `pull-requests: write` instead of repository secrets for PR labeling.
- Keeps Release Drafter itself on the trusted `push` path.
- Bumps Go to 1.26.4 so `govulncheck` uses the fixed standard library.
- Updates `golangci-lint` to v2.12.2 and migrates its config so static checks work with Go 1.26.4.
- Fixes lint findings reported by the newer linter.
- Stops asserting Neovim's runtime-generated diagnostic namespace in Lua tests.

## Related Changes

https://github.com/nobl9/nobl9-go/pull/937
